### PR TITLE
Set up maven publish tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kotlin FHIRPath
 
 [![stability-wip](https://img.shields.io/badge/stability-wip-lightgrey.svg)](https://guidelines.denpa.pro/stability#work-in-progress)
-![Static Badge](https://img.shields.io/badge/tests_passing-706%2F915-f4d03f)
+![Static Badge](https://img.shields.io/badge/tests_passing-705%2F915-f4d03f)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 Kotlin FHIRPath is an implementation of [HL7® FHIR®](https://www.hl7.org/fhir/overview.html)'s
@@ -96,7 +96,7 @@ FHIRPath but not allowed in FHIR).
 Due to the library's WIP status, not all test cases from the published official test suites are
 passing. The failures are documented in the table below.
 
-|              Test case               |     Root cause     | STU |                  Tracking issue / PR                   |                                                                                             Note                                                                                             |
+| Test case                            |     Root cause     | STU |                  Tracking issue / PR                   |                                                                                             Note                                                                                             |
 |--------------------------------------|--------------------|-----|--------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `testPolymorphismAsB`                | Test               |     | To be raised                                           | No error should be thrown according to [specification](https://hl7.org/fhirpath/#as-type-specifier).                                                                                         |
 | `testDateTimeGreaterThanDate1`       | Specification/Test |     | To be raised                                           | Unclear in the specification whether the result should still be empty if two values have different precisions but the comparison can still be "certain" (e.g. 2025 is greater than 2024-01). |
@@ -120,6 +120,7 @@ passing. The failures are documented in the table below.
 | `testAggregate*`                     | Implementation     |     |                                                        | Function `aggregate` is not implemented.                                                                                                                                                     |
 | `testIif10`                          | Implementation     |     |                                                        |                                                                                                                                                                                              |
 | `testIif11`                          | Implementation     |     |                                                        |                                                                                                                                                                                              |
+| `testMatchesSingleLineMode1`         | Implementation     |     |                                                        |                                                                                                                                                                                              |
 | `testReplace5`                       | Implementation     |     |                                                        |                                                                                                                                                                                              |
 | `testReplace6`                       | Implementation     |     |                                                        |                                                                                                                                                                                              |
 | `testEncode*`                        | Implementation     | STU |                                                        | Function `encode` is not implemented.                                                                                                                                                        |
@@ -251,6 +252,25 @@ since the `buildSrc` directory is precompiled separately in Gradle.
 ```
 
 The number of passing test cases is displayed on a badge at the top of this page.
+
+### Publishing
+
+To create a maven repository from the generated FHIR model, run:
+
+```
+./gradlew :fhirpath:publish
+```
+
+This will create a maven repository in the `fhirpath/build/repo` directory with artifacts for all
+supported platforms.
+
+To zip the repository, run:
+
+```
+./gradlew :fhirpath:zipRepo
+```
+
+This will generate a `.zip` file in the `fhirpath/build/repoZip` directory.
 
 ### Third Party
 

--- a/fhirpath/build.gradle.kts
+++ b/fhirpath/build.gradle.kts
@@ -2,6 +2,8 @@ import com.strumenta.antlrkotlin.gradle.AntlrKotlinTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import com.google.fhir.fhirpath.codegen.r4.R4HelperGenerationTask
 import com.google.fhir.fhirpath.codegen.ucum.UcumHelperGenerationTask
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -9,7 +11,11 @@ plugins {
     alias(libs.plugins.antlr.kotlin)
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.kotest)
+    `maven-publish`
 }
+
+group = "com.google.fhir"
+version = "1.0.0-alpha01"
 
 // Run `./gradlew generateR4Helpers` to generate helper functions for R4 in `fhirpath/build/generated`
 val generateR4Helpers = tasks.register<R4HelperGenerationTask>("generateR4Helpers") {
@@ -52,8 +58,32 @@ tasks.withType<Test>().configureEach {
 }
 
 kotlin {
-    jvm()
+    jvmToolchain(21)
 
+    jvm()
+    @OptIn(ExperimentalWasmDsl::class) wasmJs {
+        browser {
+            val rootDirPath = project.rootDir.path
+            val projectDirPath = project.projectDir.path
+            commonWebpackConfig {
+                devServer = (devServer ?: KotlinWebpackConfig.DevServer()).apply {
+                    static = (static ?: mutableListOf()).apply {
+                        // Serve sources to debug inside browser
+                        add(rootDirPath)
+                        add(projectDirPath)
+                    }
+                }
+            }
+        }
+    }
+    @OptIn(ExperimentalWasmDsl::class) wasmWasi {
+        nodejs()
+        binaries.library()
+    }
+    js {
+        browser()
+        binaries.library()
+    }
     androidTarget {
         compilations.all {
             compileTaskProvider.configure {
@@ -63,14 +93,13 @@ kotlin {
             }
         }
     }
-
     listOf(
         iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach {
         it.binaries.framework {
-            baseName = "shared"
+            baseName = "KotlinFhirPath"
             isStatic = true
         }
     }
@@ -123,4 +152,46 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
     dependsOn(generateR4Helpers)
     dependsOn(generateUcumHelpers)
     dependsOn(generateKotlinGrammarSource)
+}
+
+// publishing prep
+val localRepo: Directory = project.layout.buildDirectory.get().dir("repo")
+
+publishing {
+    repositories {
+        maven {
+            url = localRepo.asFile.toURI()
+        }
+    }
+    publications {
+        withType<MavenPublication> {
+            pom {
+                licenses {
+                    license {
+                        name.set("The Apache License, Version 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
+            }
+        }
+    }
+}
+val deleteRepoTask = tasks.register<Delete>("deleteLocalRepo") {
+    description =
+        "Deletes the local repository to get rid of stale artifacts before local publishing"
+    this.delete(localRepo)
+}
+tasks.named("publishAllPublicationsToMavenRepository").configure {
+    dependsOn(deleteRepoTask)
+}
+tasks.register("zipRepo", Zip::class) {
+    description = "Create a zip of the maven repository"
+    this.destinationDirectory.set(project.layout.buildDirectory.dir("repoZip"))
+    archiveBaseName.set("kotlin-fhirpath")
+
+    // Hint to gradle that the repo files are produced by the publish task. This establishes a
+    // dependency from the zipRepo task to the publish task.
+    this.from(tasks.named("publish").map { _ ->
+        localRepo
+    })
 }

--- a/fhirpath/src/commonMain/kotlin/com/google/fhir/fhirpath/functions/Strings.kt
+++ b/fhirpath/src/commonMain/kotlin/com/google/fhir/fhirpath/functions/Strings.kt
@@ -102,7 +102,7 @@ internal fun Collection<Any>.matches(params: List<Any>): Collection<Any> {
   check(size <= 1) { "matches() cannot be called on a collection with more than 1 item" }
   val input = singleOrNull()?.unwrapString() ?: return emptyList()
   val regex = params.singleOrNull()?.unwrapString() ?: return emptyList()
-  return listOf(regex.toRegexInSingleLineMode().containsMatchIn(input))
+  return listOf(regex.toRegex().containsMatchIn(input))
 }
 
 /**
@@ -112,7 +112,7 @@ internal fun Collection<Any>.matchesFull(params: List<Any>): Collection<Any> {
   check(size <= 1) { "matches() cannot be called on a collection with more than 1 item" }
   val input = singleOrNull()?.unwrapString() ?: return emptyList()
   val regex = params.singleOrNull()?.unwrapString() ?: return emptyList()
-  return listOf(input.matches(regex.toRegexInSingleLineMode()))
+  return listOf(input.matches(regex.toRegex()))
 }
 
 /**
@@ -132,7 +132,7 @@ internal fun Collection<Any>.replaceMatches(params: List<Any>): Collection<Any> 
   if (regex.isEmpty()) {
     return this
   }
-  return listOf(input.replace(regex.toRegexInSingleLineMode(), substitution))
+  return listOf(input.replace(regex.toRegex(), substitution))
 }
 
 /** See [specification](https://hl7.org/fhirpath/N1/#length-integer). */
@@ -179,8 +179,4 @@ private fun Any.unwrapString(): String? {
     is String -> this
     else -> null
   }
-}
-
-private fun String.toRegexInSingleLineMode(): Regex {
-  return toRegex(RegexOption.DOT_MATCHES_ALL)
 }


### PR DESCRIPTION
- Set up the `publish` and `zipRepo` tasks and add documentation
- Add wasm wasi and wasm js targets
- Fix a build error in the `Strings.kt` file (this results in another test failure which will need to be addressed in the future)
- Enable jvmToolChain for more robust build workflow