### PR TITLE
Add android release target to the build

### DIFF
--- a/fhirpath/build.gradle.kts
+++ b/fhirpath/build.gradle.kts
@@ -85,6 +85,7 @@ kotlin {
         binaries.library()
     }
     androidTarget {
+        publishLibraryVariants("release")
         compilations.all {
             compileTaskProvider.configure {
                 compilerOptions {


### PR DESCRIPTION
The `publish` task in the old build file didn't actually create the android target. This explicitly sets up the release variant as the published target.