### PR TITLE
Use enabled flags to disable tests instead

### DIFF
--- a/fhirpath/build.gradle.kts
+++ b/fhirpath/build.gradle.kts
@@ -120,6 +120,7 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotest.assertions.core)
             implementation(libs.kotest.framework.datatest)
+            implementation(libs.kotest.framework.engine)
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.xmlutil.serialization)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ spotless = "7.0.1"
 antlr-kotlin-runtime = { module = "com.strumenta:antlr-kotlin-runtime", version.ref = "antlr-kotlin" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-framework-datatest = { module = "io.kotest:kotest-framework-datatest", version.ref = "kotest" }
+kotest-framework-engine = {module = "io.kotest:kotest-framework-engine", version.ref = "kotest"}
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotlin-fhir = { module = "com.google.fhir:fhir-model", version.ref = "kotlin-fhir" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
We used to naively exclude the FHIRPath test cases from the test suite. This makes it difficult to keep track of ignored test cases and the reason.

The enabled flag is more explicit and makes it easier to keep track of ignored tests: https://kotest.io/docs/framework/conditional/enabled-config-flag.html