### PR TITLE
Create FHIRPathQuantity type for Quantity

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The following table lists the chosen internal types for the FHIRPath primitive t
 | Date                                                                        | FhirDate(*)                                                                   |
 | DateTime                                                                    | FhirPathDateTime(**)                                                          |
 | Time                                                                        | FhirPathTime(**)                                                              |
-| Quantity                                                                    | Quantity(*)                                                                   |
+| Quantity                                                                    | FhirPathQuantity(**)                                                          |
 
 (*): Classes defined in [Kotlin FHIR](https://github.com/google/kotlin-fhir)
 (**): Classes defined in this project

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/functions/Math.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/functions/Math.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2025-2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@
 package com.google.fhir.fhirpath.functions
 
 import com.google.fhir.fhirpath.operators.DECIMAL_MODE
-import com.google.fhir.model.r4.Quantity
+import com.google.fhir.fhirpath.toFhirPathType
+import com.google.fhir.fhirpath.types.FhirPathQuantity
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import com.ionspin.kotlin.bignum.decimal.toBigDecimal
 import kotlin.math.abs
@@ -29,12 +30,12 @@ import kotlin.math.sqrt
 /** See [specification](https://hl7.org/fhirpath/N1/#abs-integer-decimal-quantity). */
 internal fun Collection<Any>.abs(): Collection<Any> {
   check(size <= 1) { "abs() cannot be called on a collection with more than 1 item" }
-  val value = this.singleOrNull() ?: return emptyList()
+  val value = this.singleOrNull()?.toFhirPathType() ?: return emptyList()
   return when (value) {
     is Int -> listOf(abs(value))
     is Long -> listOf(abs(value))
     is BigDecimal -> listOf(value.abs())
-    is Quantity -> listOf(value.abs())
+    is FhirPathQuantity -> listOf(value.abs())
     else -> error("abs() can only be applied to numbers")
   }
 }
@@ -42,7 +43,7 @@ internal fun Collection<Any>.abs(): Collection<Any> {
 /** See [specification](https://hl7.org/fhirpath/N1/#ceiling-integer) */
 internal fun Collection<Any>.ceiling(): Collection<Any> {
   check(size <= 1) { "ceiling() cannot be called on a collection with more than 1 item" }
-  val value = this.singleOrNull() ?: return emptyList()
+  val value = this.singleOrNull()?.toFhirPathType() ?: return emptyList()
   return when (value) {
     is Int,
     Long -> listOf(value)
@@ -55,7 +56,7 @@ internal fun Collection<Any>.ceiling(): Collection<Any> {
 /** See [specification](https://hl7.org/fhirpath/N1/#exp-decimal) */
 internal fun Collection<Any>.exp(): Collection<Any> {
   check(size <= 1) { "exp() cannot be called on a collection with more than 1 item" }
-  val value = this.singleOrNull() ?: return emptyList()
+  val value = this.singleOrNull()?.toFhirPathType() ?: return emptyList()
   return when (value) {
     is Int -> listOf(exp(value.toDouble()).toBigDecimal())
     is Long -> listOf(exp(value.toDouble()).toBigDecimal())
@@ -67,7 +68,7 @@ internal fun Collection<Any>.exp(): Collection<Any> {
 /** See [specification](https://hl7.org/fhirpath/N1/#floor-integer) */
 internal fun Collection<Any>.floor(): Collection<Any> {
   check(size <= 1) { "floor() cannot be called on a collection with more than 1 item" }
-  val value = this.singleOrNull() ?: return emptyList()
+  val value = this.singleOrNull()?.toFhirPathType() ?: return emptyList()
   return when (value) {
     is Int,
     Long -> listOf(value)
@@ -80,7 +81,7 @@ internal fun Collection<Any>.floor(): Collection<Any> {
 /** See [specification](https://hl7.org/fhirpath/N1/#ln-decimal) */
 internal fun Collection<Any>.ln(): Collection<Any> {
   check(size <= 1) { "ln() cannot be called on a collection with more than 1 item" }
-  val value = this.singleOrNull() ?: return emptyList()
+  val value = this.singleOrNull()?.toFhirPathType() ?: return emptyList()
   return when (value) {
     is Int -> listOf(ln(value.toDouble()).toBigDecimal())
     is Long -> listOf(ln(value.toDouble()).toBigDecimal())
@@ -93,14 +94,14 @@ internal fun Collection<Any>.ln(): Collection<Any> {
 internal fun Collection<Any>.log(params: List<Any>): Collection<Any> {
   check(size <= 1) { "log() cannot be called on a collection with more than 1 item" }
   val valueDouble =
-    when (val value = this.singleOrNull() ?: return emptyList()) {
+    when (val value = this.singleOrNull()?.toFhirPathType() ?: return emptyList()) {
       is Int -> value.toDouble()
       is Long -> value.toDouble()
       is BigDecimal -> value.doubleValue()
       else -> error("log() can only be applied to numbers")
     }
   val baseDouble =
-    when (val param = params.singleOrNull() ?: return emptyList()) {
+    when (val param = params.singleOrNull()?.toFhirPathType() ?: return emptyList()) {
       is Int -> param.toDouble()
       is Long -> param.toDouble()
       is BigDecimal -> param.doubleValue()
@@ -114,8 +115,8 @@ internal fun Collection<Any>.log(params: List<Any>): Collection<Any> {
  */
 internal fun Collection<Any>.power(params: List<Any>): Collection<Any> {
   check(size <= 1) { "power() cannot be called on a collection with more than 1 item" }
-  val value = this.singleOrNull() ?: return emptyList()
-  val exponent = params.singleOrNull() ?: return emptyList()
+  val value = this.singleOrNull()?.toFhirPathType() ?: return emptyList()
+  val exponent = params.singleOrNull()?.toFhirPathType() ?: return emptyList()
   val valueDouble =
     when (value) {
       is Int -> value.toDouble()
@@ -148,8 +149,8 @@ internal fun Collection<Any>.power(params: List<Any>): Collection<Any> {
 /** See [specification](https://hl7.org/fhirpath/N1/#roundprecision-integer-decimal) */
 internal fun Collection<Any>.round(params: List<Any>): Collection<Any> {
   check(size <= 1) { "round() cannot be called on a collection with more than 1 item" }
-  val value = this.singleOrNull() ?: return emptyList()
-  val precision = params.singleOrNull()?.let { it as Int } ?: 0
+  val value = this.singleOrNull()?.toFhirPathType() ?: return emptyList()
+  val precision = params.singleOrNull()?.toFhirPathType()?.let { it as Int } ?: 0
   check(precision >= 0) { "round() precision must be non-negative" }
   return when (value) {
     is Int -> listOf(value.toBigDecimal())
@@ -166,7 +167,7 @@ internal fun Collection<Any>.round(params: List<Any>): Collection<Any> {
 internal fun Collection<Any>.sqrt(): Collection<Any> {
   check(size <= 1) { "sqrt() cannot be called on a collection with more than 1 item" }
   val valueDouble =
-    when (val value = this.singleOrNull() ?: return emptyList()) {
+    when (val value = this.singleOrNull()?.toFhirPathType() ?: return emptyList()) {
       is Int -> value.toDouble()
       is Long -> value.toDouble()
       is BigDecimal -> value.doubleValue()
@@ -180,7 +181,7 @@ internal fun Collection<Any>.sqrt(): Collection<Any> {
 /** See [specification](https://hl7.org/fhirpath/N1/#truncate-integer) */
 internal fun Collection<Any>.truncate(): Collection<Any> {
   check(size <= 1) { "truncate() cannot be called on a collection with more than 1 item" }
-  val value = this.singleOrNull() ?: return emptyList()
+  val value = this.singleOrNull()?.toFhirPathType() ?: return emptyList()
   return when (value) {
     is Int,
     Long -> listOf(value)
@@ -189,6 +190,6 @@ internal fun Collection<Any>.truncate(): Collection<Any> {
   }
 }
 
-/** Returns a new [Quantity] that is the absolute value of this quantity. */
-private fun Quantity.abs(): Quantity =
-  toBuilder().apply { this.value?.apply { this.value = this.value?.abs() } }.build()
+/** Returns a new [FhirPathQuantity] that is the absolute value of this quantity. */
+private fun FhirPathQuantity.abs(): FhirPathQuantity =
+  FhirPathQuantity(value = value!!.abs(), code = code)

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Comparison.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Comparison.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2025-2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ package com.google.fhir.fhirpath.operators
 import com.google.fhir.fhirpath.asComparableOperands
 import com.google.fhir.fhirpath.toEqualCanonicalized
 import com.google.fhir.fhirpath.types.FhirPathDateTime
+import com.google.fhir.fhirpath.types.FhirPathQuantity
 import com.google.fhir.fhirpath.types.FhirPathTime
 import com.google.fhir.model.r4.FhirDate
-import com.google.fhir.model.r4.Quantity
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 
 internal fun compare(left: Any, right: Any): Int? {
@@ -40,10 +40,10 @@ internal fun compare(left: Any, right: Any): Int? {
     leftFhirPath is BigDecimal && rightFhirPath is BigDecimal -> {
       leftFhirPath.compareTo(rightFhirPath)
     }
-    leftFhirPath is Quantity && rightFhirPath is Quantity -> {
+    leftFhirPath is FhirPathQuantity && rightFhirPath is FhirPathQuantity -> {
       with(leftFhirPath.toEqualCanonicalized() to rightFhirPath.toEqualCanonicalized()) {
-        if (first.code?.value!! != second.code?.value!!) return null
-        return first.value?.value?.compareTo(second.value!!.value!!)
+        if (first.code!! != second.code!!) return null
+        return first.value?.compareTo(second.value!!)
       }
     }
     leftFhirPath is FhirDate && rightFhirPath is FhirDate -> leftFhirPath.compareTo(rightFhirPath)

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Equality.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Equality.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2025-2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,11 @@ package com.google.fhir.fhirpath.operators
 import com.google.fhir.fhirpath.asComparableOperands
 import com.google.fhir.fhirpath.toEqualCanonicalized
 import com.google.fhir.fhirpath.toEquivalentCanonicalized
+import com.google.fhir.fhirpath.toFhirPathType
 import com.google.fhir.fhirpath.types.FhirPathDateTime
+import com.google.fhir.fhirpath.types.FhirPathQuantity
 import com.google.fhir.fhirpath.types.FhirPathTime
 import com.google.fhir.model.r4.FhirDate
-import com.google.fhir.model.r4.Quantity
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 
 /**
@@ -82,7 +83,8 @@ internal fun equivalent(left: Collection<Any>, right: Collection<Any>): Boolean 
 
 /** See [specification](https://hl7.org/fhirpath/N1/#equals). */
 private fun itemsEqual(left: Any, right: Any): Boolean? {
-  val (leftFhirPath, rightFhirPath) = (left to right).asComparableOperands()
+  val (leftFhirPath, rightFhirPath) =
+    (left.toFhirPathType() to right.toFhirPathType()).asComparableOperands()
 
   return when {
     leftFhirPath is String && rightFhirPath is String -> {
@@ -110,10 +112,10 @@ private fun itemsEqual(left: Any, right: Any): Boolean? {
     leftFhirPath is FhirPathTime && rightFhirPath is FhirPathTime -> {
       leftFhirPath == rightFhirPath
     }
-    leftFhirPath is Quantity && rightFhirPath is Quantity -> {
+    leftFhirPath is FhirPathQuantity && rightFhirPath is FhirPathQuantity -> {
       with(leftFhirPath.toEqualCanonicalized() to rightFhirPath.toEqualCanonicalized()) {
-        val leftUnits = parseUcumUnit(first.code?.value!!)
-        val rightUnits = parseUcumUnit(second.code?.value!!)
+        val leftUnits = parseUcumUnit(first.code!!)
+        val rightUnits = parseUcumUnit(second.code!!)
         if (leftUnits != rightUnits) return null
         return first.value == second.value
       }
@@ -126,7 +128,8 @@ private fun itemsEqual(left: Any, right: Any): Boolean? {
 
 /** See [specification](https://hl7.org/fhirpath/N1/#equivalent). */
 private fun itemsEquivalent(left: Any, right: Any): Boolean {
-  val (leftFhirPath, rightFhirPath) = (left to right).asComparableOperands()
+  val (leftFhirPath, rightFhirPath) =
+    (left.toFhirPathType() to right.toFhirPathType()).asComparableOperands()
 
   return when {
     leftFhirPath is String && rightFhirPath is String -> {
@@ -159,9 +162,9 @@ private fun itemsEquivalent(left: Any, right: Any): Boolean {
     leftFhirPath is FhirPathTime && rightFhirPath is FhirPathTime -> {
       leftFhirPath == rightFhirPath
     }
-    leftFhirPath is Quantity && rightFhirPath is Quantity -> {
+    leftFhirPath is FhirPathQuantity && rightFhirPath is FhirPathQuantity -> {
       with(leftFhirPath.toEquivalentCanonicalized() to rightFhirPath.toEquivalentCanonicalized()) {
-        return first.value == second.value && first.code?.value!! == second.code?.value!!
+        return first.value == second.value && first.code!! == second.code!!
       }
     }
     // TODO: Handle implicit conversion from Date to DateTime

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/types/FhirPathDateTime.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/types/FhirPathDateTime.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2025-2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.UtcOffset
 import kotlinx.datetime.toInstant
 
-internal data class FhirPathDateTime(
+data class FhirPathDateTime(
   val year: Int,
   val month: Int? = null,
   val day: Int? = null,
@@ -34,7 +34,6 @@ internal data class FhirPathDateTime(
   val second: Double? = null,
   val utcOffset: UtcOffset? = null,
 ) {
-
   enum class Precision {
     YEAR,
     MONTH,

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/types/FhirPathQuantity.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/types/FhirPathQuantity.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.fhir.fhirpath.types
+
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+
+data class FhirPathQuantity(val value: BigDecimal? = null, val code: String? = null)

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/types/FhirPathTime.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/types/FhirPathTime.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2025-2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,7 @@ package com.google.fhir.fhirpath.types
 import kotlin.text.get
 import kotlinx.datetime.LocalTime
 
-internal data class FhirPathTime(
-  val hour: Int,
-  val minute: Int? = null,
-  val second: Double? = null,
-) {
-
+data class FhirPathTime(val hour: Int, val minute: Int? = null, val second: Double? = null) {
   enum class Precision {
     HOUR,
     MINUTE,


### PR DESCRIPTION
This is part of the effort to address #13

This PR also:

- Make `FhirPathDateTime` and `FhirPathTime` public
- Stop conversion from FHIR type to FHIRPath type in `MoreAny.kt` (and add comment)
- Convert FHIR type to FHIRPath type at the last minute when needed (e.g. in `operators/Math.kt`, `operators/Comparison.kt`, `operators/Equality.kt`, `functions/Math.kt`)