### PR TITLE
Implement FhirPathDate

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,19 +84,15 @@ The following table lists the chosen internal types for the FHIRPath primitive t
 | Integer                                                                     | kotlin.Int                                                                    |
 | Long                                                                        | kotlin.Long                                                                   |
 | Decimal                                                                     | com.ionspin.kotlin.bignum.decimal.BigDecimal                                  |
-| Date                                                                        | FhirDate(*)                                                                   |
-| DateTime                                                                    | FhirPathDateTime(**)                                                          |
-| Time                                                                        | FhirPathTime(**)                                                              |
-| Quantity                                                                    | FhirPathQuantity(**)                                                          |
+| Date                                                                        | FhirPathDate                                                                  |
+| DateTime                                                                    | FhirPathDateTime                                                              |
+| Time                                                                        | FhirPathTime                                                                  |
+| Quantity                                                                    | FhirPathQuantity                                                              |
 
-(*): Classes defined in [Kotlin FHIR](https://github.com/google/kotlin-fhir)
-(**): Classes defined in this project
-
-Classes from the [Kotlin FHIR](https://github.com/google/kotlin-fhir) are used for more complex
-types that do not have direct representations in Kotlin. For DateTime and Time, the requirements in
-FHIRPath are more lenient than in the FHIR specification. As a result, custom classes need to be
-authored to handle cases where the minutes, seconds, or milliseconds are not present (allowed in
-FHIRPath but not allowed in FHIR).
+This project defines Date, DateTime, Time, and Quantity classes in order to implement the FHIRPath
+specification across different FHIR versions. In particular, DateTime and Time in FHIRPath may
+include partial time (e.g. missing minutes and seconds), which is not allowed in FHIR. Therefore,
+new implementations are needed.
 
 ### Timezone offset in date time values
 

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/FhirPathEvaluator.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/FhirPathEvaluator.kt
@@ -36,10 +36,10 @@ import com.google.fhir.fhirpath.operators.subtraction
 import com.google.fhir.fhirpath.operators.xor
 import com.google.fhir.fhirpath.parsers.fhirpathBaseVisitor
 import com.google.fhir.fhirpath.parsers.fhirpathParser
+import com.google.fhir.fhirpath.types.FhirPathDate
 import com.google.fhir.fhirpath.types.FhirPathDateTime
 import com.google.fhir.fhirpath.types.FhirPathQuantity
 import com.google.fhir.fhirpath.types.FhirPathTime
-import com.google.fhir.model.r4.FhirDate
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import com.ionspin.kotlin.bignum.decimal.toBigDecimal
 import kotlin.time.Clock
@@ -282,7 +282,7 @@ internal class FhirPathEvaluator(initialContext: Any?) : fhirpathBaseVisitor<Col
 
   override fun visitDateLiteral(ctx: fhirpathParser.DateLiteralContext): Collection<Any> {
     val dateString = ctx.text.removePrefix("@")
-    return listOf(FhirDate.fromString(dateString)!!)
+    return listOf(FhirPathDate.fromString(dateString))
   }
 
   override fun visitDateTimeLiteral(ctx: fhirpathParser.DateTimeLiteralContext): Collection<Any> {
@@ -299,7 +299,7 @@ internal class FhirPathEvaluator(initialContext: Any?) : fhirpathBaseVisitor<Col
     val number = ctx.quantity().NUMBER().text.toBigDecimal()
     val unit = ctx.quantity().unit()?.text!!
     val pair = (number to unit)
-    return listOf(FhirPathQuantity(value = pair.first, code = pair.second))
+    return listOf(FhirPathQuantity(value = pair.first, unit = pair.second))
   }
 
   // invocation
@@ -480,7 +480,7 @@ internal class FhirPathEvaluator(initialContext: Any?) : fhirpathBaseVisitor<Col
 
 /** Returns a new [FhirPathQuantity] object with the numeric value negated. */
 private fun FhirPathQuantity.negate(): FhirPathQuantity =
-  FhirPathQuantity(value = value?.negate(), code = code)
+  FhirPathQuantity(value = value?.negate(), unit = unit)
 
 /** See [specification](https://hl7.org/fhirpath/#string). */
 private fun unescapeFhirPathString(string: String) =

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/FhirPathType.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/FhirPathType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2025-2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@
 package com.google.fhir.fhirpath
 
 import com.google.fhir.fhirpath.ext.getFhirType
+import com.google.fhir.fhirpath.types.FhirPathDate
 import com.google.fhir.fhirpath.types.FhirPathDateTime
+import com.google.fhir.fhirpath.types.FhirPathQuantity
 import com.google.fhir.fhirpath.types.FhirPathTime
-import com.google.fhir.model.r4.FhirDate
-import com.google.fhir.model.r4.Quantity
 import com.google.fhir.model.r4.Resource
 import com.google.fhir.model.r4.terminologies.ResourceType
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
@@ -58,21 +58,21 @@ sealed interface FhirPathType {
         }
       }
 
-      // Unqualified type names are resolved as FHIRPath system types first and then FHIR types.
-      SystemType.fromString(name)?.let {
-        return it
-      }
+      // Unqualified type names are resolved as FHIR types first and then FHIRPath system types, as
+      // specified in https://hl7.org/fhirpath/#models.
       FhirPrimitiveType.fromString(name)?.let {
         return it
       }
       FhirComplexType.fromString(name)?.let {
         return it
       }
-      return try {
-        FhirResourceType(ResourceType.fromCode(name))
-      } catch (_: Exception) {
-        error("Unknown type $string")
+      try {
+        return FhirResourceType(ResourceType.fromCode(name))
+      } catch (_: Exception) {}
+      SystemType.fromString(name)?.let {
+        return it
       }
+      error("Unknown type $string")
     }
 
     fun fromObject(value: Any): FhirPathType? {
@@ -139,10 +139,10 @@ enum class SystemType(override val typeName: String) : FhirPathType {
         is Int -> INTEGER
         is Long -> LONG
         is BigDecimal -> DECIMAL
-        is FhirDate -> DATE
+        is FhirPathDate -> DATE
         is FhirPathDateTime -> DATETIME
         is FhirPathTime -> TIME
-        is Quantity -> QUANTITY
+        is FhirPathQuantity -> QUANTITY
         else -> null
       }
     }

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/Ucum.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/Ucum.kt
@@ -39,7 +39,7 @@ internal fun FhirPathQuantity.toEquivalentCanonicalized() =
  * Rhodes. This change has not yet been made in the latest version of the specification.
  */
 private fun FhirPathQuantity.toEqualUcumDefiniteDuration(): FhirPathQuantity {
-  val calendarDurationCode = code ?: return this
+  val calendarDurationCode = unit ?: return this
   val ucumDefinitionDurationCode =
     when (calendarDurationCode) {
       "week",
@@ -56,7 +56,7 @@ private fun FhirPathQuantity.toEqualUcumDefiniteDuration(): FhirPathQuantity {
       "milliseconds" -> "'ms'"
       else -> return this
     }
-  return FhirPathQuantity(value = value, code = ucumDefinitionDurationCode)
+  return FhirPathQuantity(value = value, unit = ucumDefinitionDurationCode)
 }
 
 /**
@@ -66,7 +66,7 @@ private fun FhirPathQuantity.toEqualUcumDefiniteDuration(): FhirPathQuantity {
  * See [specification](https://hl7.org/fhirpath/N1/#time-valued-quantities).
  */
 private fun FhirPathQuantity.toEquivalentUcumDefiniteDuration(): FhirPathQuantity {
-  val calendarDurationCode = code ?: return this
+  val calendarDurationCode = unit ?: return this
   val ucumDefinitionDurationCode =
     when (calendarDurationCode) {
       "year",
@@ -87,7 +87,7 @@ private fun FhirPathQuantity.toEquivalentUcumDefiniteDuration(): FhirPathQuantit
       "milliseconds" -> "'ms'"
       else -> return this
     }
-  return FhirPathQuantity(value = value, code = ucumDefinitionDurationCode)
+  return FhirPathQuantity(value = value, unit = ucumDefinitionDurationCode)
 }
 
 /**
@@ -98,14 +98,14 @@ private fun FhirPathQuantity.toEquivalentUcumDefiniteDuration(): FhirPathQuantit
  */
 private fun FhirPathQuantity.stripUcumPrefix(): FhirPathQuantity {
   // TODO: Handle more complex UCUM strings
-  val code = code?.stripSingleQuotes() ?: return this
+  val code = unit?.stripSingleQuotes() ?: return this
   for (prefix in Prefix.entries) {
     if (!code.startsWith(prefix.code)) continue
     val codeWithoutPrefix = code.removePrefix(prefix.code)
     if (codeWithoutPrefix in (BaseUnit.entries.map { it.code } + Unit.entries.map { it.code })) {
       return FhirPathQuantity(
         value = value!! * 10.0.pow(prefix.power).toBigDecimal(),
-        code = "'$codeWithoutPrefix'",
+        unit = "'$codeWithoutPrefix'",
       )
     }
   }
@@ -124,16 +124,16 @@ private fun FhirPathQuantity.stripUcumPrefix(): FhirPathQuantity {
  * - 1.0 'g' -> 1.0 'g1' (to be comparable to kg and other units derived from grams)
  */
 private fun FhirPathQuantity.toCanonicalizedUcumUnit(): FhirPathQuantity {
-  val unitCode = code?.stripSingleQuotes() ?: return this
+  val unitCode = unit?.stripSingleQuotes() ?: return this
 
   // Process base units
   BaseUnit.fromString(unitCode)?.let {
-    return FhirPathQuantity(value = value!!, code = "'${it.code}1'")
+    return FhirPathQuantity(value = value!!, unit = "'${it.code}1'")
   }
 
   // Process derived units
   Unit.fromString(unitCode)?.let {
-    return FhirPathQuantity(value = value!! * it.scalar.toBigDecimal(), code = "'${it.base}'")
+    return FhirPathQuantity(value = value!! * it.scalar.toBigDecimal(), unit = "'${it.base}'")
   }
 
   return this

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/functions/Conversion.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/functions/Conversion.kt
@@ -17,15 +17,11 @@
 package com.google.fhir.fhirpath.functions
 
 import com.google.fhir.fhirpath.toFhirPathType
+import com.google.fhir.fhirpath.types.FhirPathDate
 import com.google.fhir.fhirpath.types.FhirPathDateTime
 import com.google.fhir.fhirpath.types.FhirPathQuantity
 import com.google.fhir.fhirpath.types.FhirPathTime
 import com.google.fhir.fhirpath.ucum.Unit
-import com.google.fhir.model.r4.Date
-import com.google.fhir.model.r4.DateTime
-import com.google.fhir.model.r4.FhirDate
-import com.google.fhir.model.r4.FhirDateTime
-import com.google.fhir.model.r4.Time
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import com.ionspin.kotlin.bignum.decimal.toBigDecimal
 import kotlinx.datetime.LocalTime
@@ -123,17 +119,17 @@ internal fun Collection<Any>.convertsToInteger(): Collection<Boolean> {
 }
 
 /** See [specification](https://hl7.org/fhirpath/N1/#todate-date). */
-internal fun Collection<Any>.toDate(): Collection<FhirDate> {
+internal fun Collection<Any>.toDate(): Collection<FhirPathDate> {
   check(size <= 1) { "toDate() cannot be called on a collection with more than 1 item" }
 
   if (isEmpty()) return emptyList()
 
   return when (val value = single().toFhirPathType()) {
-    is FhirDate -> listOf(value)
-    is FhirDateTime -> TODO("Clarify the requirement in the specification")
+    is FhirPathDate -> listOf(value)
+    is FhirPathDateTime -> TODO("Clarify the requirement in the specification")
     is String ->
       try {
-        listOf(FhirDate.fromString(value)!!)
+        listOf(FhirPathDate.fromString(value))
       } catch (_: Exception) {
         emptyList()
       }
@@ -148,11 +144,11 @@ internal fun Collection<Any>.convertsToDate(): Collection<Boolean> {
   if (isEmpty()) return emptyList()
 
   return when (val value = single().toFhirPathType()) {
-    is FhirDate -> listOf(true)
-    is FhirDateTime -> listOf(true)
+    is FhirPathDate -> listOf(true)
+    is FhirPathDateTime -> listOf(true)
     is String ->
       try {
-        FhirDate.fromString(value)
+        FhirPathDate.fromString(value)
         listOf(true)
       } catch (_: Exception) {
         listOf(false)
@@ -169,8 +165,7 @@ internal fun Collection<Any>.toDateTime(): Collection<FhirPathDateTime> {
 
   return when (val value = single().toFhirPathType()) {
     is FhirPathDateTime -> listOf(value)
-    is FhirDateTime -> listOf(FhirPathDateTime.fromFhirDateTime(value))
-    is FhirDate -> listOf(FhirPathDateTime.fromString(value.toString()))
+    is FhirPathDate -> listOf(FhirPathDateTime.fromString(value.toString()))
     is String ->
       try {
         listOf(FhirPathDateTime.fromString(value))
@@ -189,8 +184,7 @@ internal fun Collection<Any>.convertsToDateTime(): Collection<Boolean> {
 
   return when (val value = single().toFhirPathType()) {
     is FhirPathDateTime -> listOf(true)
-    is FhirDateTime -> listOf(true)
-    is FhirDate -> listOf(true)
+    is FhirPathDate -> listOf(true)
     is String ->
       try {
         FhirPathDateTime.fromString(value)
@@ -237,15 +231,15 @@ internal fun Collection<Any>.toQuantity(targetUnit: String?): Collection<FhirPat
   return when (val item = single().toFhirPathType()) {
     is Int -> {
       val pair = (item.toBigDecimal() to DEFAULT_UNIT)
-      listOf(FhirPathQuantity(value = pair.first, code = pair.second))
+      listOf(FhirPathQuantity(value = pair.first, unit = pair.second))
     }
     is Long -> {
       val pair1 = (item.toBigDecimal() to DEFAULT_UNIT)
-      listOf(FhirPathQuantity(value = pair1.first, code = pair1.second))
+      listOf(FhirPathQuantity(value = pair1.first, unit = pair1.second))
     }
     is BigDecimal -> {
       val pair1 = (item to DEFAULT_UNIT)
-      listOf(FhirPathQuantity(value = pair1.first, code = pair1.second))
+      listOf(FhirPathQuantity(value = pair1.first, unit = pair1.second))
     }
     is FhirPathQuantity -> listOf(item)
     is String -> {
@@ -272,11 +266,11 @@ internal fun Collection<Any>.toQuantity(targetUnit: String?): Collection<FhirPat
         }
       }
       val pair = (value to (unit?.let { "'$it'" } ?: calendarDuration ?: DEFAULT_UNIT))
-      listOf(FhirPathQuantity(value = pair.first, code = pair.second))
+      listOf(FhirPathQuantity(value = pair.first, unit = pair.second))
     }
     is Boolean -> {
       val pair1 = ((if (item) BigDecimal.ONE else BigDecimal.ZERO) to DEFAULT_UNIT)
-      listOf(FhirPathQuantity(value = pair1.first, code = pair1.second))
+      listOf(FhirPathQuantity(value = pair1.first, unit = pair1.second))
     }
     else -> emptyList()
   }
@@ -302,14 +296,11 @@ internal fun Collection<Any>.toStringFun(): Collection<String> {
     is Int -> listOf(item.toString())
     is Long -> listOf(item.toString())
     is BigDecimal -> listOf(item.toString())
-    is Date -> listOf(item.toString())
-    is DateTime -> listOf(item.toString())
-    is Time -> listOf(item.toString())
-    is FhirDate -> listOf(item.toString())
+    is FhirPathDate -> listOf(item.toString())
     is FhirPathDateTime -> listOf(item.toString())
     is FhirPathTime -> listOf(item.toString())
     is Boolean -> listOf(item.toString())
-    is FhirPathQuantity -> listOf("${item.value} ${item.code}")
+    is FhirPathQuantity -> listOf("${item.value} ${item.unit}")
     else -> emptyList()
   }
 }
@@ -333,10 +324,7 @@ internal fun Collection<Any>.convertsToString(): Collection<Boolean> {
       is Int,
       is Long,
       is BigDecimal,
-      is Date,
-      is DateTime,
-      is Time,
-      is FhirDate,
+      is FhirPathDate,
       is FhirPathDateTime,
       is FhirPathTime,
       is Boolean,

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/functions/Math.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/functions/Math.kt
@@ -192,4 +192,4 @@ internal fun Collection<Any>.truncate(): Collection<Any> {
 
 /** Returns a new [FhirPathQuantity] that is the absolute value of this quantity. */
 private fun FhirPathQuantity.abs(): FhirPathQuantity =
-  FhirPathQuantity(value = value!!.abs(), code = code)
+  FhirPathQuantity(value = value!!.abs(), unit = unit)

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/functions/Utility.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/functions/Utility.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2025-2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.google.fhir.fhirpath.functions
 
+import com.google.fhir.fhirpath.types.FhirPathDate
 import com.google.fhir.fhirpath.types.FhirPathDateTime
 import com.google.fhir.fhirpath.types.FhirPathTime
 import com.google.fhir.model.r4.FhirDate
@@ -67,10 +68,10 @@ internal fun timeOfDay(now: Instant): Collection<Any> {
 
 /** See [specification](https://build.fhir.org/ig/HL7/FHIRPath/#today--date). */
 @OptIn(ExperimentalTime::class)
-internal fun today(now: Instant): Collection<FhirDate> {
+internal fun today(now: Instant): Collection<FhirPathDate> {
   val systemTimeZone = TimeZone.currentSystemDefault()
   val localDateTime = now.toLocalDateTime(systemTimeZone)
-  return listOf(FhirDate.Date(localDateTime.date))
+  return listOf(FhirPathDate.fromString(localDateTime.date.toString()))
 }
 
 /**

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Comparison.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Comparison.kt
@@ -18,10 +18,10 @@ package com.google.fhir.fhirpath.operators
 
 import com.google.fhir.fhirpath.asComparableOperands
 import com.google.fhir.fhirpath.toEqualCanonicalized
+import com.google.fhir.fhirpath.types.FhirPathDate
 import com.google.fhir.fhirpath.types.FhirPathDateTime
 import com.google.fhir.fhirpath.types.FhirPathQuantity
 import com.google.fhir.fhirpath.types.FhirPathTime
-import com.google.fhir.model.r4.FhirDate
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 
 internal fun compare(left: Any, right: Any): Int? {
@@ -42,25 +42,16 @@ internal fun compare(left: Any, right: Any): Int? {
     }
     leftFhirPath is FhirPathQuantity && rightFhirPath is FhirPathQuantity -> {
       with(leftFhirPath.toEqualCanonicalized() to rightFhirPath.toEqualCanonicalized()) {
-        if (first.code!! != second.code!!) return null
+        if (first.unit!! != second.unit!!) return null
         return first.value?.compareTo(second.value!!)
       }
     }
-    leftFhirPath is FhirDate && rightFhirPath is FhirDate -> leftFhirPath.compareTo(rightFhirPath)
+    leftFhirPath is FhirPathDate && rightFhirPath is FhirPathDate ->
+      leftFhirPath.compareTo(rightFhirPath)
     leftFhirPath is FhirPathDateTime && rightFhirPath is FhirPathDateTime ->
       leftFhirPath.compareTo(rightFhirPath)
     leftFhirPath is FhirPathTime && rightFhirPath is FhirPathTime ->
       leftFhirPath.compareTo(rightFhirPath)
     else -> error("Cannot compare $leftFhirPath and $rightFhirPath")
-  }
-}
-
-private fun FhirDate.compareTo(other: FhirDate): Int? {
-  return when {
-    this is FhirDate.Year && other is FhirDate.Year -> this.value compareTo other.value
-    this is FhirDate.YearMonth && other is FhirDate.YearMonth ->
-      compareValuesBy(this, other, { it.value.year }, { it.value.month })
-    this is FhirDate.Date && other is FhirDate.Date -> this.date compareTo other.date
-    else -> null
   }
 }

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Equality.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Equality.kt
@@ -114,8 +114,8 @@ private fun itemsEqual(left: Any, right: Any): Boolean? {
     }
     leftFhirPath is FhirPathQuantity && rightFhirPath is FhirPathQuantity -> {
       with(leftFhirPath.toEqualCanonicalized() to rightFhirPath.toEqualCanonicalized()) {
-        val leftUnits = parseUcumUnit(first.code!!)
-        val rightUnits = parseUcumUnit(second.code!!)
+        val leftUnits = parseUcumUnit(first.unit!!)
+        val rightUnits = parseUcumUnit(second.unit!!)
         if (leftUnits != rightUnits) return null
         return first.value == second.value
       }
@@ -164,7 +164,7 @@ private fun itemsEquivalent(left: Any, right: Any): Boolean {
     }
     leftFhirPath is FhirPathQuantity && rightFhirPath is FhirPathQuantity -> {
       with(leftFhirPath.toEquivalentCanonicalized() to rightFhirPath.toEquivalentCanonicalized()) {
-        return first.value == second.value && first.code!! == second.code!!
+        return first.value == second.value && first.unit!! == second.unit!!
       }
     }
     // TODO: Handle implicit conversion from Date to DateTime

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/types/FhirPathDate.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/types/FhirPathDate.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025-2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.fhir.fhirpath.types
+
+import com.google.fhir.model.r4.FhirDate
+import kotlin.time.ExperimentalTime
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.YearMonth
+
+internal data class FhirPathDate(val year: Int, val month: Int? = null, val day: Int? = null) {
+
+  enum class Precision {
+    YEAR,
+    MONTH,
+    DAY,
+  }
+
+  val precision =
+    when {
+      day != null -> Precision.DAY
+      month != null -> Precision.MONTH
+      else -> Precision.YEAR
+    }
+
+  @OptIn(ExperimentalTime::class)
+  fun compareTo(other: FhirPathDate): Int? {
+    year.compareTo(other.year).let { if (it != 0) return it }
+
+    if ((month == null) != (other.month == null)) return null
+    month?.compareTo(other.month!!).let { if (it != 0) return it }
+
+    if ((day == null) != (other.day == null)) return null
+    day?.compareTo(other.day!!).let { if (it != 0) return it }
+
+    return 0
+  }
+
+  override fun toString(): String {
+    return when (precision) {
+      Precision.YEAR -> year.toString().padStart(4, '0')
+      Precision.MONTH -> "${year.toString().padStart(4, '0')}-${month.toString().padStart(2, '0')}"
+      Precision.DAY ->
+        "${year.toString().padStart(4, '0')}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}"
+    }
+  }
+
+  companion object {
+    fun fromString(string: String): FhirPathDate {
+      val regex =
+        Regex("^" + "(?<year>\\d{4})" + "(-(?<month>\\d{2})" + "(-(?<day>\\d{2}))?)?" + "$")
+
+      val match =
+        regex.find(string)
+          ?: throw IllegalArgumentException("Invalid FHIRPath Date format: $string")
+      val groups = match.groups
+
+      val year = groups["year"]!!.value.toInt()
+      val month = groups["month"]?.value?.toInt()
+      val day = groups["day"]?.value?.toInt()
+
+      // Use kotlinx.datetime for robust validation of date components
+      try {
+        if (day != null) {
+          LocalDate(year, month!!, day)
+        } else if (month != null) {
+          YearMonth(year, month)
+        }
+      } catch (e: Exception) {
+        throw IllegalArgumentException("Invalid date component in literal: $string", e)
+      }
+
+      return FhirPathDate(year, month, day)
+    }
+
+    fun fromFhirDate(fhirDate: FhirDate): FhirPathDate {
+      return fromString(fhirDate.toString())
+    }
+  }
+}

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/types/FhirPathDateTime.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/types/FhirPathDateTime.kt
@@ -23,6 +23,7 @@ import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.UtcOffset
+import kotlinx.datetime.YearMonth
 import kotlinx.datetime.toInstant
 
 data class FhirPathDateTime(
@@ -143,8 +144,9 @@ data class FhirPathDateTime(
           LocalDateTime(year, month!!, day!!, hour, minute ?: 0, second?.toInt() ?: 0)
         } else if (day != null) {
           LocalDate(year, month!!, day)
+        } else if (month != null) {
+          YearMonth(year, month)
         }
-        // TODO: Validate YearMonth using the new kotlinx.datetime.YearMonth class
       } catch (e: Exception) {
         throw IllegalArgumentException("Invalid date or time component in literal: $string", e)
       }

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/types/FhirPathQuantity.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/types/FhirPathQuantity.kt
@@ -18,4 +18,4 @@ package com.google.fhir.fhirpath.types
 
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 
-data class FhirPathQuantity(val value: BigDecimal? = null, val code: String? = null)
+data class FhirPathQuantity(val value: BigDecimal? = null, val unit: String? = null)

--- a/fhir-path/src/commonTest/kotlin/com/google/fhir/fhirpath/FhirPathEngineTest.kt
+++ b/fhir-path/src/commonTest/kotlin/com/google/fhir/fhirpath/FhirPathEngineTest.kt
@@ -16,6 +16,7 @@
 
 package com.google.fhir.fhirpath
 
+import com.google.fhir.fhirpath.types.FhirPathDate
 import com.google.fhir.fhirpath.types.FhirPathDateTime
 import com.google.fhir.model.r4.FhirR4Json
 import com.google.fhir.model.r4.Resource
@@ -63,6 +64,7 @@ val skippedTestGroupToReasonMap =
  */
 val skippedTestCaseToReasonMap =
   mapOf(
+    "testPolymorphismB" to "Strict mode is not implemented yet",
     "testPolymorphismAsB" to
       "No error should be thrown according to https://hl7.org/fhirpath/#as-type-specifier",
     "testDateTimeGreaterThanDate1" to
@@ -103,7 +105,6 @@ val skippedTestCaseToReasonMap =
       "Ordered function validation not implemented. Test expects error when using skip() on unordered collection (children()), but engine does not track collection ordering.",
     "testSimpleFail" to "Strict mode is not implemented yet",
     "testSimpleWithWrongContext" to "Strict mode is not implemented yet",
-    "testPolymorphismB" to "Strict mode is not implemented yet",
     "testPolymorphicsB" to "Allow invalid test where it's not strict mode but expects output",
     "testIndex" to "TBD",
     "testPeriodInvariantOld" to "hasValue() is not implemented.",
@@ -164,7 +165,7 @@ private fun assertEquals(expected: List<Output>, actual: Collection<Any>) {
 
 private fun assertEquals(expected: Output, actual: Any) {
   when (expected.type) {
-    "date" -> assertEquals(expected.value, "@$actual")
+    "date" -> assertEquals(FhirPathDate.fromString(expected.value.trimStart('@')), actual)
     "dateTime" -> assertEquals(FhirPathDateTime.fromString(expected.value.trimStart('@')), actual)
     "code" -> assertEquals(expected.value, actual)
     "string" -> {


### PR DESCRIPTION
This is part of #13

This PR also does the following: 

- Correct the order to resolve unqualified type names as specified in https://hl7.org/fhirpath/#models.
- Rename `code` to `unit` in `FhirPathQuantity`
- Validate YearMonth using kotlinx.datetime library