### PR TITLE
Move Ucum functions from Math.kt to Ucum.kt

### DIFF
--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/Ucum.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/Ucum.kt
@@ -32,10 +32,7 @@ internal fun FhirPathQuantity.toEquivalentCanonicalized() =
   toEquivalentUcumDefiniteDuration().stripUcumPrefix().toCanonicalizedUcumUnit()
 
 /** Multiplies two quantities, combining their UCUM units. */
-internal fun multiplyQuantities(
-  left: FhirPathQuantity,
-  right: FhirPathQuantity,
-): FhirPathQuantity {
+internal fun multiplyQuantities(left: FhirPathQuantity, right: FhirPathQuantity): FhirPathQuantity {
   val leftCanonical = left.toEqualCanonicalized()
   val rightCanonical = right.toEqualCanonicalized()
 

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/Ucum.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/Ucum.kt
@@ -20,6 +20,8 @@ import com.google.fhir.fhirpath.types.FhirPathQuantity
 import com.google.fhir.fhirpath.ucum.BaseUnit
 import com.google.fhir.fhirpath.ucum.Prefix
 import com.google.fhir.fhirpath.ucum.Unit
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import com.ionspin.kotlin.bignum.decimal.DecimalMode
 import com.ionspin.kotlin.bignum.decimal.toBigDecimal
 import kotlin.math.pow
 
@@ -28,6 +30,45 @@ internal fun FhirPathQuantity.toEqualCanonicalized() =
 
 internal fun FhirPathQuantity.toEquivalentCanonicalized() =
   toEquivalentUcumDefiniteDuration().stripUcumPrefix().toCanonicalizedUcumUnit()
+
+/** Multiplies two quantities, combining their UCUM units. */
+internal fun multiplyQuantities(
+  left: FhirPathQuantity,
+  right: FhirPathQuantity,
+): FhirPathQuantity {
+  val leftCanonical = left.toEqualCanonicalized()
+  val rightCanonical = right.toEqualCanonicalized()
+
+  val resultValue = leftCanonical.value!! * rightCanonical.value!!
+
+  val leftUnits = parseUcumUnit(leftCanonical.unit ?: "")
+  val rightUnits = parseUcumUnit(rightCanonical.unit ?: "")
+  val combinedUnits = leftUnits * rightUnits
+  val resultUnitString = formatUcumUnit(combinedUnits)
+
+  return FhirPathQuantity(value = resultValue, unit = resultUnitString)
+}
+
+/** Divides two quantities, combining their UCUM units. Returns `null` if the divisor is zero. */
+internal fun divideQuantities(
+  left: FhirPathQuantity,
+  right: FhirPathQuantity,
+  decimalMode: DecimalMode,
+): FhirPathQuantity? {
+  val leftCanonical = left.toEqualCanonicalized()
+  val rightCanonical = right.toEqualCanonicalized()
+
+  if (rightCanonical.value!! == BigDecimal.ZERO) return null
+
+  val resultValue = leftCanonical.value!!.divide(rightCanonical.value, decimalMode)
+
+  val leftUnits = parseUcumUnit(leftCanonical.unit ?: "")
+  val rightUnits = parseUcumUnit(rightCanonical.unit ?: "")
+  val combinedUnits = leftUnits / rightUnits
+  val resultUnitString = formatUcumUnit(combinedUnits)
+
+  return FhirPathQuantity(value = resultValue, unit = resultUnitString)
+}
 
 /**
  * Converts a FHIRPath calendar duration to the equal UCUM definite unit if there is one. Returns
@@ -141,4 +182,161 @@ private fun FhirPathQuantity.toCanonicalizedUcumUnit(): FhirPathQuantity {
 
 private fun String.stripSingleQuotes(): String {
   return if (startsWith("'") && endsWith("'")) trim('\'') else this
+}
+
+/**
+ * Splits a UCUM unit string into components, preserving the separator (`.` or `/`) with each
+ * component.
+ *
+ * Examples:
+ * - `"m"` → `["m"]`
+ * - `"m/s"` → `["m", "/s"]`
+ * - `"m.s-2"` → `["m", ".s-2"]`
+ * - `"m/s.kg"` → `["m", "/s", ".kg"]`
+ *
+ * Uses lookahead regex to split before separators without consuming them.
+ */
+private fun splitUcumComponents(unitString: String): List<String> {
+  return unitString.split(Regex("(?=[./])"))
+}
+
+/**
+ * Parses a unit component (e.g., "m2", "s-1") into unit name and exponent. Defaults to exponent 1
+ * if not specified.
+ *
+ * Examples:
+ * - `"m"` → `Pair("m", 1)`
+ * - `"m2"` → `Pair("m", 2)`
+ * - `"s-1"` → `Pair("s", -1)`
+ * - `"kg-2"` → `Pair("kg", -2)`
+ * - `"123"` → `null` (no unit letters)
+ */
+private fun parseUnitAndExponent(component: String): Pair<String, Int>? {
+  val match = Regex("([a-zA-Z]+)(-?\\d*)").matchEntire(component) ?: return null
+  val unit = match.groupValues[1]
+  val exponentStr = match.groupValues[2]
+  val exponent = if (exponentStr.isEmpty()) 1 else exponentStr.toInt()
+  return Pair(unit, exponent)
+}
+
+/**
+ * Parses a UCUM unit string into a map of unit names to exponents. Once `/` is encountered, all
+ * subsequent units (even after `.`) become negative (denominator).
+ *
+ * Examples:
+ * - `"'m'"` → `{m=1}`
+ * - `"m2"` → `{m=2}`
+ * - `"g/m"` → `{g=1, m=-1}`
+ * - `"m2.s-2"` → `{m=2, s=-2}`
+ * - `"m/s.kg"` → `{m=1, s=-1, kg=-1}` (both s and kg in denominator)
+ * - `"'1'"` → `{}` (dimensionless)
+ *
+ * Throws error if duplicate units found (e.g., "m.m").
+ */
+internal fun parseUcumUnit(unitString: String): Map<String, Int> {
+  // Strip single quotes if present
+  val cleanString = unitString.trim('\'')
+  if (cleanString.isEmpty() || cleanString == "1") return emptyMap()
+
+  val result = mutableMapOf<String, Int>()
+  val components = splitUcumComponents(cleanString)
+
+  var inDenominator = false
+  for (component in components) {
+    if (component.startsWith("/")) {
+      inDenominator = true
+    }
+
+    val cleanComponent = component.removePrefix("/").removePrefix(".")
+
+    val parsed = parseUnitAndExponent(cleanComponent)
+    if (parsed != null) {
+      val (unit, exponent) = parsed
+      val finalExponent = if (inDenominator) -exponent else exponent
+      if (result.containsKey(unit))
+        error("Duplicate unit '$unit' in UCUM unit string '$unitString'")
+      result[unit] = finalExponent
+    }
+  }
+
+  return result
+}
+
+/**
+ * Multiplies two unit maps by adding exponents (a^m × a^n = a^(m+n)). Filters out units that cancel
+ * to zero.
+ *
+ * UCUM units are handled naively without canonicalization in this operation. For example, `kg` and
+ * `g` are considered separate units. Similarly, `W` is not handled as `J/s` (therefore cannot be
+ * multiplied with `s` to get `J`).
+ *
+ * Examples:
+ * - `{m=1} * {m=1}` → `{m=2}`
+ * - `{m=2, s=-1} * {s=1}` → `{m=2}` (s cancels)
+ * - `{g=1} * {m=1}` → `{g=1, m=1}`
+ * - `{m=1} * {m=-1}` → `{}` (dimensionless)
+ */
+private operator fun Map<String, Int>.times(other: Map<String, Int>): Map<String, Int> {
+  val result = this.toMutableMap()
+  for ((unit, exponent) in other) {
+    result[unit] = (result[unit] ?: 0) + exponent
+  }
+  return result.filterValues { it != 0 }
+}
+
+/**
+ * Divides two unit maps by subtracting exponents (a^m ÷ a^n = a^(m-n)). Filters out units that
+ * cancel to zero.
+ *
+ * UCUM units are handled naively without canonicalization in this operation. For example, `kg` and
+ * `g` are considered separate units. Similarly, `W` is not handled as `J/s` (therefore cannot be
+ * multiplied with `s` to get `J`).
+ *
+ * Examples:
+ * - `{m=1} / {m=1}` → `{}` (dimensionless)
+ * - `{m=2} / {m=1}` → `{m=1}`
+ * - `{g=1, m=1} / {m=1}` → `{g=1}` (m cancels)
+ * - `{m=1} / {s=1}` → `{m=1, s=-1}`
+ * - `{}` / `{s=1}` → `{s=-1}`
+ */
+private operator fun Map<String, Int>.div(other: Map<String, Int>): Map<String, Int> {
+  val result = this.toMutableMap()
+  for ((unit, exponent) in other) {
+    result[unit] = (result[unit] ?: 0) - exponent
+  }
+  return result.filterValues { it != 0 }
+}
+
+/**
+ * Formats a unit map into a UCUM string with inline notation. Units sorted alphabetically, joined
+ * with `.`. Omits exponent when it's 1.
+ *
+ * Examples:
+ * - `{}` → `"'1'"` (dimensionless)
+ * - `{m=1}` → `"'m'"`
+ * - `{m=2}` → `"'m2'"`
+ * - `{g=1, m=-1}` → `"'g.m-1'"`
+ * - `{m=2, s=-2}` → `"'m2.s-2'"`
+ * - `{kg=-1, m=1, s=-1}` → `"'kg-1.m.s-1'"`
+ * - `{s=-1}` → `"'s-1'"` (Hz frequency)
+ *
+ * Throws error if any unit has exponent 0 (should never happen due to filtering).
+ */
+private fun formatUcumUnit(units: Map<String, Int>): String {
+  if (units.isEmpty()) return "'1'"
+
+  val unitString =
+    units.entries
+      .sortedBy { it.key }
+      .joinToString(".") { (unit, exp) ->
+        when {
+          exp == 1 -> unit // m
+          exp > 1 -> "$unit$exp" // m2
+          exp < 0 -> "$unit$exp" // m-2
+          exp == 0 -> error("Unit should not have zero exponent: $unit")
+          else -> error("Unit must be an integer: $unit")
+        }
+      }
+
+  return "'$unitString'"
 }

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/Ucum.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/Ucum.kt
@@ -20,8 +20,6 @@ import com.google.fhir.fhirpath.types.FhirPathQuantity
 import com.google.fhir.fhirpath.ucum.BaseUnit
 import com.google.fhir.fhirpath.ucum.Prefix
 import com.google.fhir.fhirpath.ucum.Unit
-import com.ionspin.kotlin.bignum.decimal.BigDecimal
-import com.ionspin.kotlin.bignum.decimal.DecimalMode
 import com.ionspin.kotlin.bignum.decimal.toBigDecimal
 import kotlin.math.pow
 
@@ -30,42 +28,6 @@ internal fun FhirPathQuantity.toEqualCanonicalized() =
 
 internal fun FhirPathQuantity.toEquivalentCanonicalized() =
   toEquivalentUcumDefiniteDuration().stripUcumPrefix().toCanonicalizedUcumUnit()
-
-/** Multiplies two quantities, combining their UCUM units. */
-internal fun multiplyQuantities(left: FhirPathQuantity, right: FhirPathQuantity): FhirPathQuantity {
-  val leftCanonical = left.toEqualCanonicalized()
-  val rightCanonical = right.toEqualCanonicalized()
-
-  val resultValue = leftCanonical.value!! * rightCanonical.value!!
-
-  val leftUnits = parseUcumUnit(leftCanonical.unit ?: "")
-  val rightUnits = parseUcumUnit(rightCanonical.unit ?: "")
-  val combinedUnits = leftUnits * rightUnits
-  val resultUnitString = formatUcumUnit(combinedUnits)
-
-  return FhirPathQuantity(value = resultValue, unit = resultUnitString)
-}
-
-/** Divides two quantities, combining their UCUM units. Returns `null` if the divisor is zero. */
-internal fun divideQuantities(
-  left: FhirPathQuantity,
-  right: FhirPathQuantity,
-  decimalMode: DecimalMode,
-): FhirPathQuantity? {
-  val leftCanonical = left.toEqualCanonicalized()
-  val rightCanonical = right.toEqualCanonicalized()
-
-  if (rightCanonical.value!! == BigDecimal.ZERO) return null
-
-  val resultValue = leftCanonical.value!!.divide(rightCanonical.value, decimalMode)
-
-  val leftUnits = parseUcumUnit(leftCanonical.unit ?: "")
-  val rightUnits = parseUcumUnit(rightCanonical.unit ?: "")
-  val combinedUnits = leftUnits / rightUnits
-  val resultUnitString = formatUcumUnit(combinedUnits)
-
-  return FhirPathQuantity(value = resultValue, unit = resultUnitString)
-}
 
 /**
  * Converts a FHIRPath calendar duration to the equal UCUM definite unit if there is one. Returns
@@ -273,7 +235,7 @@ internal fun parseUcumUnit(unitString: String): Map<String, Int> {
  * - `{g=1} * {m=1}` → `{g=1, m=1}`
  * - `{m=1} * {m=-1}` → `{}` (dimensionless)
  */
-private operator fun Map<String, Int>.times(other: Map<String, Int>): Map<String, Int> {
+internal operator fun Map<String, Int>.times(other: Map<String, Int>): Map<String, Int> {
   val result = this.toMutableMap()
   for ((unit, exponent) in other) {
     result[unit] = (result[unit] ?: 0) + exponent
@@ -296,7 +258,7 @@ private operator fun Map<String, Int>.times(other: Map<String, Int>): Map<String
  * - `{m=1} / {s=1}` → `{m=1, s=-1}`
  * - `{}` / `{s=1}` → `{s=-1}`
  */
-private operator fun Map<String, Int>.div(other: Map<String, Int>): Map<String, Int> {
+internal operator fun Map<String, Int>.div(other: Map<String, Int>): Map<String, Int> {
   val result = this.toMutableMap()
   for ((unit, exponent) in other) {
     result[unit] = (result[unit] ?: 0) - exponent
@@ -319,7 +281,7 @@ private operator fun Map<String, Int>.div(other: Map<String, Int>): Map<String, 
  *
  * Throws error if any unit has exponent 0 (should never happen due to filtering).
  */
-private fun formatUcumUnit(units: Map<String, Int>): String {
+internal fun formatUcumUnit(units: Map<String, Int>): String {
   if (units.isEmpty()) return "'1'"
 
   val unitString =

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Equality.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Equality.kt
@@ -17,6 +17,7 @@
 package com.google.fhir.fhirpath.operators
 
 import com.google.fhir.fhirpath.asComparableOperands
+import com.google.fhir.fhirpath.parseUcumUnit
 import com.google.fhir.fhirpath.toEqualCanonicalized
 import com.google.fhir.fhirpath.toEquivalentCanonicalized
 import com.google.fhir.fhirpath.toFhirPathType

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Math.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Math.kt
@@ -16,7 +16,8 @@
 
 package com.google.fhir.fhirpath.operators
 
-import com.google.fhir.fhirpath.toEqualCanonicalized
+import com.google.fhir.fhirpath.divideQuantities
+import com.google.fhir.fhirpath.multiplyQuantities
 import com.google.fhir.fhirpath.toFhirPathType
 import com.google.fhir.fhirpath.types.FhirPathDate
 import com.google.fhir.fhirpath.types.FhirPathDateTime
@@ -84,17 +85,7 @@ internal fun multiplication(
       listOf(leftItem * rightItem)
     }
     leftItem is FhirPathQuantity && rightItem is FhirPathQuantity -> {
-      val leftCanonical = leftItem.toEqualCanonicalized()
-      val rightCanonical = rightItem.toEqualCanonicalized()
-
-      val resultValue = leftCanonical.value!! * rightCanonical.value!!
-
-      val leftUnits = parseUcumUnit(leftCanonical.unit ?: "")
-      val rightUnits = parseUcumUnit(rightCanonical.unit ?: "")
-      val combinedUnits = leftUnits * rightUnits
-      val resultUnitString = formatUcumUnit(combinedUnits)
-
-      listOf(FhirPathQuantity(value = resultValue, unit = resultUnitString))
+      listOf(multiplyQuantities(leftItem, rightItem))
     }
     else -> error("Cannot multiply $leftItem and $rightItem")
   }
@@ -110,19 +101,7 @@ internal fun division(
   val rightItem = right.singleOrNull()?.toFhirPathType(fhirPathTypeResolver) ?: return emptyList()
 
   if (leftItem is FhirPathQuantity && rightItem is FhirPathQuantity) {
-    val leftCanonical = leftItem.toEqualCanonicalized()
-    val rightCanonical = rightItem.toEqualCanonicalized()
-
-    if (rightCanonical.value!! == BigDecimal.ZERO) return emptyList()
-
-    val resultValue = leftCanonical.value!!.divide(rightCanonical.value, DECIMAL_MODE)
-
-    val leftUnits = parseUcumUnit(leftCanonical.unit ?: "")
-    val rightUnits = parseUcumUnit(rightCanonical.unit ?: "")
-    val combinedUnits = leftUnits / rightUnits
-    val resultUnitString = formatUcumUnit(combinedUnits)
-
-    return listOf(FhirPathQuantity(value = resultValue, unit = resultUnitString))
+    return divideQuantities(leftItem, rightItem, DECIMAL_MODE)?.let { listOf(it) } ?: emptyList()
   }
 
   val leftBigDecimal =
@@ -268,163 +247,6 @@ internal fun concat(left: Collection<Any>, right: Collection<Any>): Collection<A
 
 private operator fun FhirPathQuantity.times(multiplier: BigDecimal): FhirPathQuantity {
   return FhirPathQuantity(value = this.value!! * multiplier, unit = this.unit)
-}
-
-/**
- * Splits a UCUM unit string into components, preserving the separator (`.` or `/`) with each
- * component.
- *
- * Examples:
- * - `"m"` → `["m"]`
- * - `"m/s"` → `["m", "/s"]`
- * - `"m.s-2"` → `["m", ".s-2"]`
- * - `"m/s.kg"` → `["m", "/s", ".kg"]`
- *
- * Uses lookahead regex to split before separators without consuming them.
- */
-private fun splitUcumComponents(unitString: String): List<String> {
-  return unitString.split(Regex("(?=[./])"))
-}
-
-/**
- * Parses a unit component (e.g., "m2", "s-1") into unit name and exponent. Defaults to exponent 1
- * if not specified.
- *
- * Examples:
- * - `"m"` → `Pair("m", 1)`
- * - `"m2"` → `Pair("m", 2)`
- * - `"s-1"` → `Pair("s", -1)`
- * - `"kg-2"` → `Pair("kg", -2)`
- * - `"123"` → `null` (no unit letters)
- */
-private fun parseUnitAndExponent(component: String): Pair<String, Int>? {
-  val match = Regex("([a-zA-Z]+)(-?\\d*)").matchEntire(component) ?: return null
-  val unit = match.groupValues[1]
-  val exponentStr = match.groupValues[2]
-  val exponent = if (exponentStr.isEmpty()) 1 else exponentStr.toInt()
-  return Pair(unit, exponent)
-}
-
-/**
- * Parses a UCUM unit string into a map of unit names to exponents. Once `/` is encountered, all
- * subsequent units (even after `.`) become negative (denominator).
- *
- * Examples:
- * - `"'m'"` → `{m=1}`
- * - `"m2"` → `{m=2}`
- * - `"g/m"` → `{g=1, m=-1}`
- * - `"m2.s-2"` → `{m=2, s=-2}`
- * - `"m/s.kg"` → `{m=1, s=-1, kg=-1}` (both s and kg in denominator)
- * - `"'1'"` → `{}` (dimensionless)
- *
- * Throws error if duplicate units found (e.g., "m.m").
- */
-internal fun parseUcumUnit(unitString: String): Map<String, Int> {
-  // Strip single quotes if present
-  val cleanString = unitString.trim('\'')
-  if (cleanString.isEmpty() || cleanString == "1") return emptyMap()
-
-  val result = mutableMapOf<String, Int>()
-  val components = splitUcumComponents(cleanString)
-
-  var inDenominator = false
-  for (component in components) {
-    if (component.startsWith("/")) {
-      inDenominator = true
-    }
-
-    val cleanComponent = component.removePrefix("/").removePrefix(".")
-
-    val parsed = parseUnitAndExponent(cleanComponent)
-    if (parsed != null) {
-      val (unit, exponent) = parsed
-      val finalExponent = if (inDenominator) -exponent else exponent
-      if (result.containsKey(unit))
-        error("Duplicate unit '$unit' in UCUM unit string '$unitString'")
-      result[unit] = finalExponent
-    }
-  }
-
-  return result
-}
-
-/**
- * Multiplies two unit maps by adding exponents (a^m × a^n = a^(m+n)). Filters out units that cancel
- * to zero.
- *
- * UCUM units are handled naively without canonicalization in this operation. For example, `kg` and
- * `g` are considered separate units. Similarly, `W` is not handled as `J/s` (therefore cannot be
- * multiplied with `s` to get `J`).
- *
- * Examples:
- * - `{m=1} * {m=1}` → `{m=2}`
- * - `{m=2, s=-1} * {s=1}` → `{m=2}` (s cancels)
- * - `{g=1} * {m=1}` → `{g=1, m=1}`
- * - `{m=1} * {m=-1}` → `{}` (dimensionless)
- */
-private operator fun Map<String, Int>.times(other: Map<String, Int>): Map<String, Int> {
-  val result = this.toMutableMap()
-  for ((unit, exponent) in other) {
-    result[unit] = (result[unit] ?: 0) + exponent
-  }
-  return result.filterValues { it != 0 }
-}
-
-/**
- * Divides two unit maps by subtracting exponents (a^m ÷ a^n = a^(m-n)). Filters out units that
- * cancel to zero.
- *
- * UCUM units are handled naively without canonicalization in this operation. For example, `kg` and
- * `g` are considered separate units. Similarly, `W` is not handled as `J/s` (therefore cannot be
- * multiplied with `s` to get `J`).
- *
- * Examples:
- * - `{m=1} / {m=1}` → `{}` (dimensionless)
- * - `{m=2} / {m=1}` → `{m=1}`
- * - `{g=1, m=1} / {m=1}` → `{g=1}` (m cancels)
- * - `{m=1} / {s=1}` → `{m=1, s=-1}`
- * - `{}` / `{s=1}` → `{s=-1}`
- */
-private operator fun Map<String, Int>.div(other: Map<String, Int>): Map<String, Int> {
-  val result = this.toMutableMap()
-  for ((unit, exponent) in other) {
-    result[unit] = (result[unit] ?: 0) - exponent
-  }
-  return result.filterValues { it != 0 }
-}
-
-/**
- * Formats a unit map into a UCUM string with inline notation. Units sorted alphabetically, joined
- * with `.`. Omits exponent when it's 1.
- *
- * Examples:
- * - `{}` → `"'1'"` (dimensionless)
- * - `{m=1}` → `"'m'"`
- * - `{m=2}` → `"'m2'"`
- * - `{g=1, m=-1}` → `"'g.m-1'"`
- * - `{m=2, s=-2}` → `"'m2.s-2'"`
- * - `{kg=-1, m=1, s=-1}` → `"'kg-1.m.s-1'"`
- * - `{s=-1}` → `"'s-1'"` (Hz frequency)
- *
- * Throws error if any unit has exponent 0 (should never happen due to filtering).
- */
-private fun formatUcumUnit(units: Map<String, Int>): String {
-  if (units.isEmpty()) return "'1'"
-
-  val unitString =
-    units.entries
-      .sortedBy { it.key }
-      .joinToString(".") { (unit, exp) ->
-        when {
-          exp == 1 -> unit // m
-          exp > 1 -> "$unit$exp" // m2
-          exp < 0 -> "$unit$exp" // m-2
-          exp == 0 -> error("Unit should not have zero exponent: $unit")
-          else -> error("Unit must be an integer: $unit")
-        }
-      }
-
-  return "'$unitString'"
 }
 
 private operator fun FhirPathDate.plus(duration: FhirPathQuantity): FhirPathDate {

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Math.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Math.kt
@@ -259,9 +259,8 @@ private operator fun FhirPathQuantity.times(other: FhirPathQuantity): FhirPathQu
 
   val resultValue = leftCanonical.value!! * rightCanonical.value!!
 
-  val leftUnits = parseUcumUnit(leftCanonical.unit ?: "")
-  val rightUnits = parseUcumUnit(rightCanonical.unit ?: "")
-  val combinedUnits = leftUnits * rightUnits
+  val combinedUnits =
+    parseUcumUnit(leftCanonical.unit ?: "") * parseUcumUnit(rightCanonical.unit ?: "")
   val resultUnitString = formatUcumUnit(combinedUnits)
 
   return FhirPathQuantity(value = resultValue, unit = resultUnitString)
@@ -276,9 +275,8 @@ private operator fun FhirPathQuantity.div(other: FhirPathQuantity): FhirPathQuan
 
   val resultValue = leftCanonical.value!!.divide(rightCanonical.value, DECIMAL_MODE)
 
-  val leftUnits = parseUcumUnit(leftCanonical.unit ?: "")
-  val rightUnits = parseUcumUnit(rightCanonical.unit ?: "")
-  val combinedUnits = leftUnits / rightUnits
+  val combinedUnits =
+    parseUcumUnit(leftCanonical.unit ?: "") / parseUcumUnit(rightCanonical.unit ?: "")
   val resultUnitString = formatUcumUnit(combinedUnits)
 
   return FhirPathQuantity(value = resultValue, unit = resultUnitString)

--- a/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Math.kt
+++ b/fhir-path/src/commonMain/kotlin/com/google/fhir/fhirpath/operators/Math.kt
@@ -16,8 +16,11 @@
 
 package com.google.fhir.fhirpath.operators
 
-import com.google.fhir.fhirpath.divideQuantities
-import com.google.fhir.fhirpath.multiplyQuantities
+import com.google.fhir.fhirpath.div
+import com.google.fhir.fhirpath.formatUcumUnit
+import com.google.fhir.fhirpath.parseUcumUnit
+import com.google.fhir.fhirpath.times
+import com.google.fhir.fhirpath.toEqualCanonicalized
 import com.google.fhir.fhirpath.toFhirPathType
 import com.google.fhir.fhirpath.types.FhirPathDate
 import com.google.fhir.fhirpath.types.FhirPathDateTime
@@ -85,7 +88,7 @@ internal fun multiplication(
       listOf(leftItem * rightItem)
     }
     leftItem is FhirPathQuantity && rightItem is FhirPathQuantity -> {
-      listOf(multiplyQuantities(leftItem, rightItem))
+      listOf(leftItem * rightItem)
     }
     else -> error("Cannot multiply $leftItem and $rightItem")
   }
@@ -101,7 +104,7 @@ internal fun division(
   val rightItem = right.singleOrNull()?.toFhirPathType(fhirPathTypeResolver) ?: return emptyList()
 
   if (leftItem is FhirPathQuantity && rightItem is FhirPathQuantity) {
-    return divideQuantities(leftItem, rightItem, DECIMAL_MODE)?.let { listOf(it) } ?: emptyList()
+    return (leftItem / rightItem)?.let { listOf(it) } ?: emptyList()
   }
 
   val leftBigDecimal =
@@ -247,6 +250,38 @@ internal fun concat(left: Collection<Any>, right: Collection<Any>): Collection<A
 
 private operator fun FhirPathQuantity.times(multiplier: BigDecimal): FhirPathQuantity {
   return FhirPathQuantity(value = this.value!! * multiplier, unit = this.unit)
+}
+
+/** Multiplies two quantities, combining their UCUM units. */
+private operator fun FhirPathQuantity.times(other: FhirPathQuantity): FhirPathQuantity {
+  val leftCanonical = this.toEqualCanonicalized()
+  val rightCanonical = other.toEqualCanonicalized()
+
+  val resultValue = leftCanonical.value!! * rightCanonical.value!!
+
+  val leftUnits = parseUcumUnit(leftCanonical.unit ?: "")
+  val rightUnits = parseUcumUnit(rightCanonical.unit ?: "")
+  val combinedUnits = leftUnits * rightUnits
+  val resultUnitString = formatUcumUnit(combinedUnits)
+
+  return FhirPathQuantity(value = resultValue, unit = resultUnitString)
+}
+
+/** Divides two quantities, combining their UCUM units. Returns `null` if the divisor is zero. */
+private operator fun FhirPathQuantity.div(other: FhirPathQuantity): FhirPathQuantity? {
+  val leftCanonical = this.toEqualCanonicalized()
+  val rightCanonical = other.toEqualCanonicalized()
+
+  if (rightCanonical.value!! == BigDecimal.ZERO) return null
+
+  val resultValue = leftCanonical.value!!.divide(rightCanonical.value, DECIMAL_MODE)
+
+  val leftUnits = parseUcumUnit(leftCanonical.unit ?: "")
+  val rightUnits = parseUcumUnit(rightCanonical.unit ?: "")
+  val combinedUnits = leftUnits / rightUnits
+  val resultUnitString = formatUcumUnit(combinedUnits)
+
+  return FhirPathQuantity(value = resultValue, unit = resultUnitString)
 }
 
 private operator fun FhirPathDate.plus(duration: FhirPathQuantity): FhirPathDate {


### PR DESCRIPTION
#27

Moved from `Math.kt` to `Ucum.kt`:                                                                                                                        
- splitUcumComponents (private)                                                                                                                                           
- parseUnitAndExponent (private)                                                                                                                                          
- parseUcumUnit (internal, used by Equality.kt in a different package)                                                                                                   
- Map<String,Int>.times (private)                                                                                                                                         
- Map<String,Int>.div (private)                                                                                                                                           
- formatUcumUnit (private)

`Math.kt` is now only calling `multiplyQuantities` and `divideQuantities` (on Ucum.kt) for ucum unit related quantity operation.