### PR TITLE
Set up release to Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,22 +332,58 @@ The number of passing test cases is displayed on a badge at the top of this page
 
 ### Publishing
 
-To create a maven repository from the generated FHIR model, run:
+For a comprehensive understanding of publishing KMP libraries to Maven Central, see the
+[Kotlin Multiplatform Publishing Guide](https://kotlinlang.org/docs/multiplatform-publish-lib.html)
+and the
+[Maven Central Publishing Guide](https://central.sonatype.org/publish/publish-portal-guide/).
 
+> **Note:** The project has already been set up to be released to Maven using the
+> [`gradle-maven-publish-plugin`](https://github.com/vanniktech/gradle-maven-publish-plugin). The
+> following sections outline the additional setup required for a developer to publish to Maven Local
+> and Maven Central.
+
+#### Maven Local
+
+To publish artifacts to your local Maven repository (`~/.m2/repository`) for local development and
+testing, run:
+
+```bash
+./gradlew :fhir-path:publishToMavenLocal
 ```
-./gradlew :fhir-path:publish
+
+#### Maven Central
+
+To publish a new release to Maven Central, first set up your GPG signing key and repository
+credentials to Gradle following the aforementioned official guides.
+
+**Best Practice**: Store these sensitive details in your **Global Gradle Properties** file at
+`~/.gradle/gradle.properties` (User Home directory). This ensures they are available to all your
+projects but are never accidentally committed to the Git repository.
+
+Your `~/.gradle/gradle.properties` should contain:
+
+```properties
+# Maven Central Credentials
+mavenCentralUsername=YOUR_USERNAME
+mavenCentralPassword=YOUR_PASSWORD
+
+# GPG Key Details
+signing.keyId=YOUR_KEY_ID
+signing.password=YOUR_KEY_PASSWORD
+signing.secretKeyRingFile=/path/to/secring.gpg
 ```
 
-This will create a maven repository in the `fhir-path/build/repo` directory with artifacts for all
-supported platforms.
+You can verify your signing setup by running:
 
-To zip the repository, run:
-
-```
-./gradlew :fhir-path:zipRepo
+```bash
+./gradlew :fhir-path:checkSigningConfiguration
 ```
 
-This will generate a `.zip` file in the `fhir-path/build/repoZip` directory.
+To publish to Maven Central, run:
+
+```bash
+./gradlew :fhir-path:publishToMavenCentral
+```
 
 ### Third Party
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.androidLibrary).apply(false)
     alias(libs.plugins.kotlinMultiplatform).apply(false)
+    alias(libs.plugins.maven.publish).apply(false)
+    alias(libs.plugins.ksp).apply(false)
     alias(libs.plugins.spotless)
 }
 

--- a/fhir-path/build.gradle.kts
+++ b/fhir-path/build.gradle.kts
@@ -8,14 +8,12 @@ import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.antlr.kotlin)
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.kotest)
-    `maven-publish`
+    alias(libs.plugins.maven.publish)
 }
-
-group = "dev.ohs.fhir"
-version = "1.0.0-beta01"
 
 val fhirVersions = mapOf(
     "r4" to "third_party/hl7.fhir.r4.core/package",
@@ -129,7 +127,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotest.assertions.core)
-            implementation(libs.kotest.framework.datatest)
+            
             implementation(libs.kotest.framework.engine)
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.serialization.json)
@@ -145,7 +143,7 @@ kotlin {
 }
 
 android {
-    namespace = "dev.ohs.fhir.fhirpath"
+    namespace = project.property("androidNamespace") as String
     compileSdk = 35
     defaultConfig {
         minSdk = 24
@@ -166,44 +164,36 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
     dependsOn(generateKotlinGrammarSource)
 }
 
-// publishing prep
-val localRepo: Directory = project.layout.buildDirectory.get().dir("repo")
+version = "1.0.0-beta01"
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+    coordinates(project.property("mavenGroupId") as String, project.property("mavenArtifactId") as String, version.toString())
 
-publishing {
-    repositories {
-        maven {
-            url = localRepo.asFile.toURI()
-        }
-    }
-    publications {
-        withType<MavenPublication> {
-            pom {
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
+    pom {
+        name = "Kotlin FHIRPath"
+        description = "A Kotlin Multiplatform library for FHIRPath"
+        inceptionYear = "2025"
+        url = "https://github.com/ohs-foundation/kotlin-fhirpath"
+        licenses {
+            license {
+                name = "The Apache License, Version 2.0"
+                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "https://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         }
+        developers {
+            developer {
+                id = "ohs-foundation"
+                name = "Open Heath Stack Foundation"
+                url = "https://ohs.dev/"
+            }
+        }
+        scm {
+            url = "https://github.com/ohs-foundation/kotlin-fhirpath/"
+            connection = "scm:git:git://github.com/ohs-foundation/kotlin-fhirpath.git"
+            developerConnection = "scm:git:ssh://git@github.com/ohs-foundation/kotlin-fhirpath.git"
+        }
     }
 }
-val deleteRepoTask = tasks.register<Delete>("deleteLocalRepo") {
-    description =
-        "Deletes the local repository to get rid of stale artifacts before local publishing"
-    this.delete(localRepo)
-}
-tasks.named("publishAllPublicationsToMavenRepository").configure {
-    dependsOn(deleteRepoTask)
-}
-tasks.register("zipRepo", Zip::class) {
-    description = "Create a zip of the maven repository"
-    this.destinationDirectory.set(project.layout.buildDirectory.dir("repoZip"))
-    archiveBaseName.set("kotlin-fhirpath")
 
-    // Hint to gradle that the repo files are produced by the publish task. This establishes a
-    // dependency from the zipRepo task to the publish task.
-    this.from(tasks.named("publish").map { _ ->
-        localRepo
-    })
-}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,8 @@ kotlin.code.style=official
 #Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
+
+#Project
+mavenGroupId=dev.ohs.fhir
+mavenArtifactId=fhir-path
+androidNamespace=dev.ohs.fhir.fhirpath

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,29 +1,33 @@
 [versions]
-agp = "8.10.0"
-antlr-kotlin = "1.0.0"
-kotest = "5.9.1"
-kotlin = "2.2.0"
+agp = "8.13.0"
+antlr-kotlin = "1.0.10"
+kotest = "6.1.11"
+kotlin = "2.3.20"
 kotlin-fhir = "1.0.0-beta03"
 kotlinx-serialization-json = "1.8.1"
-xmlutil = "0.91.2"
+ksp = "2.3.6"
+maven-publish = "0.36.0"
 spotless = "7.0.1"
+xmlutil = "0.91.2"
 
 [libraries]
 antlr-kotlin-runtime = { module = "com.strumenta:antlr-kotlin-runtime", version.ref = "antlr-kotlin" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
-kotest-framework-datatest = { module = "io.kotest:kotest-framework-datatest", version.ref = "kotest" }
 kotest-framework-engine = {module = "io.kotest:kotest-framework-engine", version.ref = "kotest"}
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotlin-fhir = { module = "dev.ohs.fhir:fhir-model", version.ref = "kotlin-fhir" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+ksp = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 xmlutil-core = { module = "io.github.pdvrieze.xmlutil:core", version.ref = "xmlutil" }
 xmlutil-serialization = { module = "io.github.pdvrieze.xmlutil:serialization", version.ref = "xmlutil" }
 
 [plugins]
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 antlr-kotlin = { id = "com.strumenta.antlr-kotlin", version.ref = "antlr-kotlin" }
-kotest = { id = "io.kotest.multiplatform", version.ref = "kotest" }
+kotest = { id = "io.kotest", version.ref = "kotest" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Aug 05 14:13:39 BST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Reference PR: https://github.com/ohs-foundation/kotlin-fhir/pull/78

- Update Kotlin version to 2.3.20
- Update AGP to 8.13.0
- Update Kotest to 6.1.11
- Update the Maven Publish plugin to 0.36.0
- Introduce KSP plugin (required by Kotest)
- Set up Maven publish tasks
- Update documentation

Additionally:
- Update antlr to 1.0.10
- Introduce global variables in `gradle.properties` file